### PR TITLE
Add product and brand entities with initialization support

### DIFF
--- a/app/database/__init__.py
+++ b/app/database/__init__.py
@@ -21,6 +21,8 @@ class MongoCollections:
     users: Collection
     buttons: Collection
     game: Collection
+    brands: Collection
+    products: Collection
 
 
 def create_mongo_collections(settings: Settings) -> MongoCollections:
@@ -34,4 +36,6 @@ def create_mongo_collections(settings: Settings) -> MongoCollections:
         users=database["users"],
         buttons=database["buttons"],
         game=database["game"],
+        brands=database["brands"],
+        products=database["products"],
     )

--- a/app/database/management.py
+++ b/app/database/management.py
@@ -11,10 +11,25 @@ from app.database import MongoCollections
 __all__ = [
     "ensure_game_document",
     "ensure_buttons_collection",
+    "ensure_brands_collection",
     "reset_players",
+    "DEFAULT_BRANDS",
 ]
 
 logger = logging.getLogger(__name__)
+
+
+DEFAULT_BRANDS = (
+    "ARTFOLIO",
+    "KAARAL",
+    "INEBRYA",
+    "HELEN SEWARD",
+    "FARCOM",
+    "KAYPRO",
+    "FANOLA",
+    "JEM",
+    "OCEANYST",
+)
 
 
 def ensure_game_document(collections: MongoCollections, admin_ids: Sequence[int]) -> None:
@@ -77,6 +92,27 @@ def ensure_buttons_collection(buttons: Collection, *, reset: bool) -> None:
         logger.info("Добавлено %s стандартных кнопок", len(new_docs))
     else:
         logger.info("Кнопки уже инициализированы")
+
+
+def ensure_brands_collection(brands: Collection, brand_names: Sequence[str]) -> None:
+    """Populate the brands collection with default brand names."""
+
+    existing = {
+        doc["name"]: int(doc.get("id", 0))
+        for doc in brands.find({}, {"name": 1, "id": 1})
+    }
+    next_id = (max(existing.values()) if existing else 0) + 1
+    new_docs = []
+    for name in brand_names:
+        if name in existing:
+            continue
+        new_docs.append({"id": next_id, "name": name})
+        next_id += 1
+    if new_docs:
+        brands.insert_many(new_docs)
+        logger.info("Добавлено %s брендов", len(new_docs))
+    else:
+        logger.info("Коллекция брендов уже инициализирована")
 
 
 def reset_players(users: Collection) -> None:

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -1,0 +1,39 @@
+"""Dataclasses describing MongoDB entities used by the bot."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Dict
+
+__all__ = ["Brand", "Product"]
+
+
+@dataclass(frozen=True)
+class Brand:
+    """Representation of a cosmetic brand stored in MongoDB."""
+
+    id: int
+    name: str
+
+    def to_document(self) -> Dict[str, Any]:
+        """Return a MongoDB document representation of the brand."""
+
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class Product:
+    """Representation of a cosmetic product stored in MongoDB."""
+
+    id: int
+    photo: str
+    name: str
+    code: str
+    description: str
+    link: str
+    brand: int
+    category: str
+
+    def to_document(self) -> Dict[str, Any]:
+        """Return a MongoDB document representation of the product."""
+
+        return asdict(self)

--- a/app/database/products.py
+++ b/app/database/products.py
@@ -1,0 +1,36 @@
+"""Helpers for working with product documents in MongoDB."""
+from __future__ import annotations
+
+from typing import Mapping, MutableMapping
+
+from pymongo.collection import Collection
+
+from app.database.models import Product
+
+__all__ = ["create_product", "prepare_product_document"]
+
+
+def _next_incremental_id(collection: Collection) -> int:
+    """Return the next identifier for the provided collection."""
+
+    last_document = collection.find_one(sort=[("id", -1)], projection={"id": 1})
+    if not last_document:
+        return 1
+    return int(last_document.get("id", 0)) + 1
+
+
+def prepare_product_document(data: Mapping[str, object], *, collection: Collection) -> MutableMapping[str, object]:
+    """Prepare a MongoDB document for insertion ensuring an incremental id."""
+
+    new_id = _next_incremental_id(collection)
+    document = dict(data)
+    document["id"] = new_id
+    return document
+
+
+def create_product(collection: Collection, data: Mapping[str, object]) -> Product:
+    """Insert a new product into MongoDB with an incremental identifier."""
+
+    document = prepare_product_document(data, collection=collection)
+    collection.insert_one(document)
+    return Product(**document)  # type: ignore[arg-type]

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -7,6 +7,8 @@ import logging
 from app.config import get_settings
 from app.database import create_mongo_collections
 from app.database.management import (
+    DEFAULT_BRANDS,
+    ensure_brands_collection,
     ensure_buttons_collection,
     ensure_game_document,
     reset_players,
@@ -36,6 +38,7 @@ def main() -> None:
 
     ensure_game_document(collections, settings.all_admin_ids)
     ensure_buttons_collection(collections.buttons, reset=args.reset)
+    ensure_brands_collection(collections.brands, DEFAULT_BRANDS)
     if args.reset:
         reset_players(collections.users)
 


### PR DESCRIPTION
## Summary
- extend the MongoDB collection registry to expose brand and product collections
- add dataclasses and helpers to manage brand and product documents with incremental IDs
- seed the brands collection during database initialisation with the default brand list

## Testing
- python -m compileall app scripts

------
https://chatgpt.com/codex/tasks/task_e_68d57be799d88322a4854412bb1f4e22