### PR TITLE
Add inline main menu with catalog and help navigation

### DIFF
--- a/app/keyboards/main.py
+++ b/app/keyboards/main.py
@@ -1,7 +1,39 @@
-"""Definitions of reply keyboards used by the bot."""
-from telegram import ReplyKeyboardMarkup
+"""Definitions of inline keyboards used by the bot."""
+from __future__ import annotations
 
-START_KEYBOARD = ReplyKeyboardMarkup(
-    [["Старт"]],
-    resize_keyboard=True,
+from typing import Sequence, Tuple
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+CATALOG_CALLBACK = "main:catalog"
+HELP_CALLBACK = "main:help"
+BACK_CALLBACK = "main:back"
+BRAND_CALLBACK_PREFIX = "brand:"
+
+MAIN_MENU_KEYBOARD = InlineKeyboardMarkup(
+    [
+        [
+            InlineKeyboardButton("📋 КАТАЛОГ", callback_data=CATALOG_CALLBACK),
+            InlineKeyboardButton("🆘 ПОМОЩЬ", callback_data=HELP_CALLBACK),
+        ]
+    ]
 )
+
+BACK_BUTTON_KEYBOARD = InlineKeyboardMarkup(
+    [[InlineKeyboardButton("⬅️ НАЗАД", callback_data=BACK_CALLBACK)]]
+)
+
+
+def build_brands_keyboard(brands: Sequence[Tuple[int, str]]) -> InlineKeyboardMarkup:
+    """Return an inline keyboard with a button for every provided brand."""
+
+    rows: list[list[InlineKeyboardButton]] = [
+        [
+            InlineKeyboardButton(
+                name, callback_data=f"{BRAND_CALLBACK_PREFIX}{brand_id}"
+            )
+        ]
+        for brand_id, name in brands
+    ]
+    rows.append([InlineKeyboardButton("⬅️ НАЗАД", callback_data=BACK_CALLBACK)])
+    return InlineKeyboardMarkup(rows)


### PR DESCRIPTION
## Summary
- replace the start reply keyboard with an inline main menu that sends the welcome message
- implement catalog and help callback handlers with back navigation and message cleanup
- dynamically load brands from MongoDB for the catalog keyboard and acknowledge brand selections

## Testing
- python -m compileall app/handlers/start.py app/keyboards/main.py

------
https://chatgpt.com/codex/tasks/task_e_68d586535970832285dd51add2ba3636