### PR TITLE
Add default categories collection initialization

### DIFF
--- a/app/database/__init__.py
+++ b/app/database/__init__.py
@@ -20,6 +20,7 @@ class MongoCollections:
     database: Database
     admins: Collection
     brands: Collection
+    categories: Collection
     products: Collection
 
 
@@ -33,5 +34,6 @@ def create_mongo_collections(settings: Settings) -> MongoCollections:
         database=database,
         admins=database["admins"],
         brands=database["brands"],
+        categories=database["categories"],
         products=database["products"],
     )

--- a/app/database/management.py
+++ b/app/database/management.py
@@ -11,7 +11,9 @@ from app.database import MongoCollections
 __all__ = [
     "ensure_brands_collection",
     "ensure_admins_collection",
+    "ensure_categories_collection",
     "DEFAULT_BRANDS",
+    "DEFAULT_CATEGORIES",
 ]
 
 logger = logging.getLogger(__name__)
@@ -27,6 +29,16 @@ DEFAULT_BRANDS = (
     "FANOLA",
     "JEM",
     "OCEANYST",
+)
+
+
+DEFAULT_CATEGORIES = (
+    "шампунь",
+    "кондиционер",
+    "маска",
+    "лосьон",
+    "сыворотка",
+    "прочее",
 )
 
 def ensure_brands_collection(brands: Collection, brand_names: Sequence[str]) -> None:
@@ -48,6 +60,29 @@ def ensure_brands_collection(brands: Collection, brand_names: Sequence[str]) -> 
         logger.info("Добавлено %s брендов", len(new_docs))
     else:
         logger.info("Коллекция брендов уже инициализирована")
+
+
+def ensure_categories_collection(
+    categories: Collection, category_names: Sequence[str]
+) -> None:
+    """Populate the categories collection with default category names."""
+
+    existing = {
+        doc["name"]: int(doc.get("id", 0))
+        for doc in categories.find({}, {"name": 1, "id": 1})
+    }
+    next_id = (max(existing.values()) if existing else 0) + 1
+    new_docs = []
+    for name in category_names:
+        if name in existing:
+            continue
+        new_docs.append({"id": next_id, "name": name})
+        next_id += 1
+    if new_docs:
+        categories.insert_many(new_docs)
+        logger.info("Добавлено %s категорий", len(new_docs))
+    else:
+        logger.info("Коллекция категорий уже инициализирована")
 
 
 def ensure_admins_collection(

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 from typing import Any, Dict
 
-__all__ = ["Brand", "Product"]
+__all__ = ["Brand", "Category", "Product"]
 
 
 @dataclass(frozen=True)
@@ -16,6 +16,19 @@ class Brand:
 
     def to_document(self) -> Dict[str, Any]:
         """Return a MongoDB document representation of the brand."""
+
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class Category:
+    """Representation of a product category stored in MongoDB."""
+
+    id: int
+    name: str
+
+    def to_document(self) -> Dict[str, Any]:
+        """Return a MongoDB document representation of the category."""
 
         return asdict(self)
 

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -7,8 +7,10 @@ from app.config import get_settings
 from app.database import create_mongo_collections
 from app.database.management import (
     DEFAULT_BRANDS,
+    DEFAULT_CATEGORIES,
     ensure_admins_collection,
     ensure_brands_collection,
+    ensure_categories_collection,
 )
 
 
@@ -24,6 +26,7 @@ def main() -> None:
     collections = create_mongo_collections(settings)
 
     ensure_brands_collection(collections.brands, DEFAULT_BRANDS)
+    ensure_categories_collection(collections.categories, DEFAULT_CATEGORIES)
     ensure_admins_collection(collections.admins, settings.initial_admin_id)
 
     logging.getLogger(__name__).info("Инициализация базы данных завершена")


### PR DESCRIPTION
## Summary
- add a Category dataclass and expose the categories Mongo collection
- seed default cosmetic categories alongside brands during DB init
- provide a helper to populate the categories collection with incremental ids

## Testing
- python -m compileall app scripts

------
https://chatgpt.com/codex/tasks/task_e_68d590557534832290c31f60e7da2301