### PR TITLE
Show categories after selecting brand

### DIFF
--- a/app/keyboards/main.py
+++ b/app/keyboards/main.py
@@ -9,6 +9,7 @@ CATALOG_CALLBACK = "main:catalog"
 HELP_CALLBACK = "main:help"
 BACK_CALLBACK = "main:back"
 BRAND_CALLBACK_PREFIX = "brand:"
+CATEGORY_CALLBACK_PREFIX = "category:"
 
 MAIN_MENU_KEYBOARD = InlineKeyboardMarkup(
     [
@@ -36,4 +37,22 @@ def build_brands_keyboard(brands: Sequence[Tuple[int, str]]) -> InlineKeyboardMa
         for brand_id, name in brands
     ]
     rows.append([InlineKeyboardButton("⬅️ НАЗАД", callback_data=BACK_CALLBACK)])
+    return InlineKeyboardMarkup(rows)
+
+
+def build_categories_keyboard(
+    categories: Sequence[Tuple[int, str]], *, brand_id: int
+) -> InlineKeyboardMarkup:
+    """Return an inline keyboard with a button for each category."""
+
+    rows: list[list[InlineKeyboardButton]] = [
+        [
+            InlineKeyboardButton(
+                name,
+                callback_data=f"{CATEGORY_CALLBACK_PREFIX}{brand_id}:{category_id}",
+            )
+        ]
+        for category_id, name in categories
+    ]
+    rows.append([InlineKeyboardButton("⬅️ НАЗАД", callback_data=CATALOG_CALLBACK)])
     return InlineKeyboardMarkup(rows)


### PR DESCRIPTION
## Summary
- load available categories from MongoDB and render a category keyboard after a brand is selected
- add inline keyboard builder for categories with a back button that returns to the brand list
- register handlers to clean up old messages when navigating between catalog and category views

## Testing
- `python -m compileall app`


------
https://chatgpt.com/codex/tasks/task_e_68d591f9e1bc83228180960e5a7bb31a