### PR TITLE
Show products after category selection

### DIFF
--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -20,11 +20,14 @@ from app.keyboards.main import (
     BACK_CALLBACK,
     BRAND_CALLBACK_PREFIX,
     CATALOG_CALLBACK,
+    CATEGORY_BACK_CALLBACK_PREFIX,
     CATEGORY_CALLBACK_PREFIX,
     HELP_CALLBACK,
     MAIN_MENU_KEYBOARD,
     build_brands_keyboard,
     build_categories_keyboard,
+    build_products_keyboard,
+    PRODUCT_CALLBACK_PREFIX,
 )
 
 MAIN_MENU_MESSAGE = "Мы рады видеть вас в нашем онлайн помошнике по подбору косметики"
@@ -33,6 +36,10 @@ HELP_MESSAGE = (
     "наш бот умеет делать то или другое, и вот для помощи вам телефон нашего администратора"
 )
 CATEGORIES_MESSAGE_TEMPLATE = "Выберите категорию бренда {brand}:"
+PRODUCTS_MESSAGE_TEMPLATE = "Выберите продукт категории {category} бренда {brand}:"
+PRODUCTS_EMPTY_MESSAGE_TEMPLATE = (
+    "Для категории {category} бренда {brand} пока нет продуктов."
+)
 
 _LAST_BOT_MESSAGE_KEY = "last_bot_message_id"
 _LAST_BOT_MESSAGE_TYPE_KEY = "last_bot_message_type"
@@ -158,6 +165,50 @@ def _load_categories(context: ContextTypes.DEFAULT_TYPE) -> Sequence[Tuple[int, 
     return categories
 
 
+def _load_products(
+    context: ContextTypes.DEFAULT_TYPE, *, brand_id: int, category_id: int
+) -> Sequence[Tuple[int, str]]:
+    mongo = _get_mongo_collections(context)
+    cursor = mongo.products.find(
+        {"brand_id": brand_id, "category_id": category_id},
+        {"id": 1, "name": 1},
+    ).sort("name", 1)
+    products: List[Tuple[int, str]] = []
+    for document in cursor:
+        try:
+            product_id = int(document.get("id"))
+        except (TypeError, ValueError):
+            continue
+        name = str(document.get("name", "")).strip()
+        if not name:
+            continue
+        products.append((product_id, name))
+    return products
+
+
+async def _send_categories_menu(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    *,
+    brand_id: int,
+    brand_name: str,
+    categories: Sequence[Tuple[int, str]],
+) -> None:
+    await _cleanup_previous_messages(update, context, delete_trigger=False)
+
+    chat = update.effective_chat
+    if chat is None:
+        return
+
+    keyboard = build_categories_keyboard(categories, brand_id=brand_id)
+    message = await context.bot.send_message(
+        chat.id,
+        CATEGORIES_MESSAGE_TEMPLATE.format(brand=brand_name),
+        reply_markup=keyboard,
+    )
+    _store_last_message(context, message, message_type=f"categories:{brand_id}")
+
+
 async def _show_catalog(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     query = update.callback_query
     if query is None:
@@ -231,19 +282,13 @@ async def _brand_selected(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         return
 
     await query.answer()
-    await _cleanup_previous_messages(update, context, delete_trigger=False)
-
-    chat = update.effective_chat
-    if chat is None:
-        return
-
-    keyboard = build_categories_keyboard(categories, brand_id=brand_id)
-    message = await context.bot.send_message(
-        chat.id,
-        CATEGORIES_MESSAGE_TEMPLATE.format(brand=brand_name),
-        reply_markup=keyboard,
+    await _send_categories_menu(
+        update,
+        context,
+        brand_id=brand_id,
+        brand_name=brand_name,
+        categories=categories,
     )
-    _store_last_message(context, message, message_type=f"categories:{brand_id}")
 
 
 async def _category_selected(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -273,7 +318,84 @@ async def _category_selected(update: Update, context: ContextTypes.DEFAULT_TYPE)
         await query.answer("Категория не найдена", show_alert=True)
         return
 
-    await query.answer(f"Вы выбрали {category_name} бренда {brand_name}")
+    products = _load_products(context, brand_id=brand_id, category_id=category_id)
+
+    await query.answer()
+
+    chat = update.effective_chat
+    if chat is None:
+        return
+
+    await _cleanup_previous_messages(update, context, delete_trigger=False)
+
+    keyboard = build_products_keyboard(products, brand_id=brand_id)
+
+    if products:
+        text = PRODUCTS_MESSAGE_TEMPLATE.format(
+            brand=brand_name, category=category_name
+        )
+    else:
+        text = PRODUCTS_EMPTY_MESSAGE_TEMPLATE.format(
+            brand=brand_name, category=category_name
+        )
+
+    message = await context.bot.send_message(
+        chat.id,
+        text,
+        reply_markup=keyboard,
+    )
+    _store_last_message(
+        context,
+        message,
+        message_type=f"products:{brand_id}:{category_id}",
+    )
+
+
+async def _categories_back(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    if query is None or query.data is None:
+        return
+
+    try:
+        brand_id = int(query.data.split(":", 1)[1])
+    except (IndexError, ValueError):
+        await query.answer("Бренд не найден", show_alert=True)
+        return
+
+    mongo = _get_mongo_collections(context)
+    brand = mongo.brands.find_one({"id": brand_id}, {"name": 1})
+    brand_name = str(brand.get("name")) if brand and brand.get("name") else None
+    if not brand_name:
+        await query.answer("Бренд не найден", show_alert=True)
+        return
+
+    categories = _load_categories(context)
+    if not categories:
+        await query.answer("Категории не найдены", show_alert=True)
+        return
+
+    await query.answer()
+    await _send_categories_menu(
+        update,
+        context,
+        brand_id=brand_id,
+        brand_name=brand_name,
+        categories=categories,
+    )
+
+
+async def _product_selected(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    if query is None or query.data is None:
+        return
+
+    try:
+        int(query.data.split(":", 1)[1])
+    except (IndexError, ValueError):
+        await query.answer("Продукт не найден", show_alert=True)
+        return
+
+    await query.answer("Информация о продукте появится позже")
 
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -310,5 +432,17 @@ def register_start_handlers(application: Application) -> None:
         CallbackQueryHandler(
             _category_selected,
             pattern=f"^{CATEGORY_CALLBACK_PREFIX}\\d+:\\d+$",
+        )
+    )
+    application.add_handler(
+        CallbackQueryHandler(
+            _categories_back,
+            pattern=f"^{CATEGORY_BACK_CALLBACK_PREFIX}\\d+$",
+        )
+    )
+    application.add_handler(
+        CallbackQueryHandler(
+            _product_selected,
+            pattern=f"^{PRODUCT_CALLBACK_PREFIX}\\d+$",
         )
     )

--- a/app/keyboards/main.py
+++ b/app/keyboards/main.py
@@ -10,6 +10,8 @@ HELP_CALLBACK = "main:help"
 BACK_CALLBACK = "main:back"
 BRAND_CALLBACK_PREFIX = "brand:"
 CATEGORY_CALLBACK_PREFIX = "category:"
+CATEGORY_BACK_CALLBACK_PREFIX = "categories_back:"
+PRODUCT_CALLBACK_PREFIX = "product:"
 
 MAIN_MENU_KEYBOARD = InlineKeyboardMarkup(
     [
@@ -55,4 +57,28 @@ def build_categories_keyboard(
         for category_id, name in categories
     ]
     rows.append([InlineKeyboardButton("⬅️ НАЗАД", callback_data=CATALOG_CALLBACK)])
+    return InlineKeyboardMarkup(rows)
+
+
+def build_products_keyboard(
+    products: Sequence[Tuple[int, str]], *, brand_id: int
+) -> InlineKeyboardMarkup:
+    """Return an inline keyboard with a button for each product."""
+
+    rows: list[list[InlineKeyboardButton]] = [
+        [
+            InlineKeyboardButton(
+                name, callback_data=f"{PRODUCT_CALLBACK_PREFIX}{product_id}"
+            )
+        ]
+        for product_id, name in products
+    ]
+    rows.append(
+        [
+            InlineKeyboardButton(
+                "⬅️ НАЗАД",
+                callback_data=f"{CATEGORY_BACK_CALLBACK_PREFIX}{brand_id}",
+            )
+        ]
+    )
     return InlineKeyboardMarkup(rows)


### PR DESCRIPTION
## Summary
- show all products for a selected brand/category as inline buttons with dedicated messaging
- add back navigation from the product list to the category list and register supporting callbacks

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d5a210f760832289f5cd3262904f89