### PR TITLE
Fix relative product image path resolution

### DIFF
--- a/app/database/management.py
+++ b/app/database/management.py
@@ -174,7 +174,10 @@ def load_products_from_file(
         if not image_base64 and image_path_value:
             image_path = Path(str(image_path_value))
             if not image_path.is_absolute():
-                image_path = (path.parent / image_path).resolve()
+                if image_path.exists():
+                    image_path = image_path.resolve()
+                else:
+                    image_path = (path.parent / image_path).resolve()
             try:
                 image_base64 = base64.b64encode(image_path.read_bytes()).decode()
             except OSError as exc:


### PR DESCRIPTION
## Summary
- fix product image path resolution to avoid duplicating the app/database prefix when joining paths
- attempt to read existing relative paths before falling back to file directory

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d5b36484808322ad135bad3f1cef26