### PR TITLE
Fix HTML line breaks in product description

### DIFF
--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -441,7 +441,7 @@ async def _product_selected(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     name = html.escape(str(product.get("name", "")).strip())
     code = html.escape(str(product.get("code", "")).strip())
     description_raw = str(product.get("description", "")).strip()
-    description = html.escape(description_raw).replace("\n", "<br>")
+    description = html.escape(description_raw).replace("\n", "<br/>")
     link = str(product.get("link", "")).strip()
 
     caption_parts: list[str] = []


### PR DESCRIPTION
## Summary
- replace HTML line break tags in the product description with the self-closing `<br/>` tag to satisfy Telegram's HTML parser

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5b4f028c88322a2d770d7893c784c